### PR TITLE
added catch-all to routing

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -37,8 +37,13 @@ class Route
         $this->url = '/' . trim($url, '/');
         $this->metadata = new Metadata($metadata);
 
-        if (str_contains($this->url, '*') && !str_ends_with($this->url, '*')) {
-            throw new RoutingException('Catch-all parameter (*) can only be at the end of the route URL.');
+        if (str_contains($this->url, '*')) {
+            if (!str_ends_with($this->url, '*')) {
+                throw new RoutingException('Catch-all parameter * can only be at the end of the route URL.');
+            }
+            if ($this->url !== '*' && !str_ends_with($this->url, '/*')) {
+                throw new RoutingException('Catch-all parameter has to be a single asterisk.');
+            }
         }
 
         if (is_array($callable) && count($callable) === 2) {

--- a/tests/Classes/Controller.php
+++ b/tests/Classes/Controller.php
@@ -13,4 +13,9 @@ class Controller
     {
         return 'complex action: ' . $id . '/' . $name;
     }
+
+    public static function catchAll(string $id, string $name): string
+    {
+        return 'catchall action: ' . $id . '/' . $name;
+    }
 }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -489,6 +489,7 @@ class RouterTest extends TestCase
     private function provideCatchAllUrls(): array
     {
         return [
+            ['/catchall', [], []],
             ['/catchall/something', [], ['something']],
             ['/catchall/something/else', [], ['something', 'else']],
             ['/catch/all/something', [], ['something']],

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -440,6 +440,7 @@ class RouterTest extends TestCase
     private function provideCorrectCatchAllUrls(): array
     {
         return [
+            ['*'],
             ['/catchall/*'],
             ['/catchall/*/'],
             ['/catchall/{some}/*'],
@@ -462,6 +463,9 @@ class RouterTest extends TestCase
         return [
             ['/catchall/*/something'],
             ['/catchall/*/{param}'],
+            ['/catchall/**'],
+            ['/catchall/blah*'],
+            ['/catchall/*blah'],
         ];
     }
 
@@ -471,6 +475,7 @@ class RouterTest extends TestCase
     public function testCatchAllUrl(string $url, array $expectedParams, array $expectedCatchAllValues): void
     {
         $this->setUpDefaultRoutesAndAssert();
+        $this->router->addRoute(new Route(['GET'], 'catchEverything', '*', fn() => null));
 
         $route = $this->router->match('GET', $url);
 
@@ -490,6 +495,9 @@ class RouterTest extends TestCase
             ['/catch/all/something/else', [], ['something', 'else']],
             ['/catch/more/something', ['more'], ['something']],
             ['/catch/more/something/else', ['more'], ['something', 'else']],
+            ['/everything', [], ['everything']],
+            ['/catching/everything', [], ['catching', 'everything']],
+            ['/and/catching/everything', [], ['and', 'catching','everything']],
         ];
     }
 }


### PR DESCRIPTION
With this change, a route URL can end with `*` to catch all request URLs matching the start of the route URL. Any fixed sections have to match (duh), any parametered sections are stored as usual (ParameterValues), and all remaining sections (which can be `[]`!) are stored in catchAllValues in the Route.
